### PR TITLE
Made slicing/indexation of time series more robust w.r.t. time zones

### DIFF
--- a/forcateri/data/timeseries.py
+++ b/forcateri/data/timeseries.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import datetime, tzinfo
 from typing import List, Optional, Union, Tuple, Callable, Dict, Any
 from typing_extensions import Self
 
@@ -111,6 +111,17 @@ class TimeSeries:
         Whether the series has offsets other than 0.
         """
         return (len(self.offsets) != 1) or (self.offsets[0] != pd.Timedelta(0))
+
+    @property
+    def tz(self) -> tzinfo | None:
+        """The time zone of the series.
+
+        Returns
+        _______
+        datetime.tzinfo
+            The time zone of the time series or None if the series is timezone-naive.
+        """
+        return self.data.index.get_level_values(TimeSeries.ROW_INDEX_NAMES[1]).tz
 
     def _check_freq_format(self, index: pd.Index, freq: Optional[str] = None) -> None:
         """
@@ -752,6 +763,16 @@ class TimeSeries:
             When the step property of a slice is not None.
         """
 
+        def check_tz_compatibilizy(dt: pd.Timestamp):
+            if self.tz is None and dt.tz is not None:
+                raise TypeError(
+                    f"Attempting to slice a timezone-naive time series via a timezone-aware index {dt}."
+                )
+            elif self.tz is not None and dt.tz is None:
+                raise TypeError(
+                    f"Attempting to slice a timezone-aware time series ({self.tz}) via a timezone-naive index."
+                )
+
         # conversion of various formats into timestamps
         def to_dt(i) -> Optional[Union[pd.Timestamp, slice]]:
             match i:
@@ -765,14 +786,15 @@ class TimeSeries:
                     else:
                         return slice(to_dt(i.start), to_dt(i.stop))
                 case pd.Timestamp():
-                    return i.tz_convert("utc")
+                    check_tz_compatibilizy(i)
+                    return i
                 case datetime():
-                    return pd.Timestamp(i).tz_convert("utc")
+                    return to_dt(pd.Timestamp(i))
                 case int():
-                    return self.timestamps[i].tz_convert("utc")
+                    return self.timestamps[i]
                 case float():
                     if i == 1.0:
-                        return self.timestamps[-1].tz_convert("utc")
+                        return self.timestamps[-1]
                     elif 0.0 <= i < 1.0:
                         return to_dt(int(np.round(len(self) * i)))
                     else:


### PR DESCRIPTION
This branch should be safe to merge into main, now. Also into iss42, if desired.

1. Slicing and indexation of time series should work more reliably, when the slice reaches across summer/winter time. Accessing with a timestamp from a different time zone than the one of the time series should work now, too, e.g. one can use a utc-timestamp to index a time series is in "Europe/Berlin" and vice versa. 
2. Timezone-naive series and indexes work, as well. Mixing, time zone naive and time zone aware time series and slices, on the other hand, raises TypeErrors explaining the incompatibility.
3. Indexing a time series through `1.0` now yields the last time stamp rather than the one after, thereby avoiding an out-of-bounds error.
4. `TimeSeries` now have a property `tz` indicating the time zone of the time series. For time zone naive series it is None.