### PR TITLE
Robust slicing

### DIFF
--- a/forcateri/data/timeseries.py
+++ b/forcateri/data/timeseries.py
@@ -797,7 +797,7 @@ class TimeSeries:
                     return self.timestamps[i]
                 case float():
                     if 0.0 <= i < 1.0:
-                        return to_dt(int(np.round(len(self) * i)))
+                        return to_dt(int(np.round((len(self) - 1) * i)))
                     else:
                         raise IndexError(
                             "Float indexation of TimeSeries must be between 0.0 and 1.0"
@@ -814,9 +814,12 @@ class TimeSeries:
         # back to imitate the behavior of range() in excluding the upper bound.
         # One step back should also work but it depends heavier on the implementation of pandas.
         elif index.stop in self.data.index.get_level_values(1):
+            upper_bound = index.stop - pd.Timedelta(1, unit=self.freq) * 0.5
+            if self.tz is not None:
+                upper_bound = upper_bound.tz_convert("utc")
             index = slice(
                 index.start,
-                (index.stop - pd.Timedelta(1, unit=self.freq) * 0.5).tz_convert("utc"),
+                upper_bound,
             )
 
         # slice the underlying data


### PR DESCRIPTION
This branch should be safe to merge into main, now. Also into iss42, if desired.
Upon merging into main, #78 will be closed.

Summary of the changes:
1. `TimeSeries` now have a property `tz` indicating the time zone of the time series. For time zone naive series it is None.
1. Slicing and indexation of time series should work more reliably, when the slice reaches across summer/winter time.
1. Accessing with a timestamp from a different time zone than the one of the time series should work now, too, e.g. one can use a utc-timestamp to index a time series is in "Europe/Berlin" and vice versa.
1. Timezone-naive series and indexes work, as expected.
1. Mixing time zone naive and time zone aware time series and slices raises `TypeError`s explaining the incompatibility.
1. Indexing a time series through `1.0` now yields the last time stamp rather than the one after, thereby avoiding an out-of-bounds error.
1. Converting indexes to UTC internally to allow for more general slicing with mixed types, e.g., `ts[pd.Timestamp(2000,1,1, tz="Europe/Berlin"): 0.6]`