### PR TITLE
84 further simplify the creation of timeseries

### DIFF
--- a/forcateri/data/timeseries.py
+++ b/forcateri/data/timeseries.py
@@ -310,9 +310,8 @@ class TimeSeries:
                 df.index.get_level_values(0), pd.DatetimeIndex
             ) or isinstance(df.index.get_level_values(1), pd.DatetimeIndex)
             if not isinstance(df.columns, pd.MultiIndex):
-                if has_datetime:
-                    logger.info("Index is MultiIndex with datetime values.")
-                    return True
+                #If not multiindex datetimeindex is enough, if no datetimeindex then it is not compatible
+                return has_datetime
             else:
                 has_datetime = isinstance(
                     df.index.get_level_values(0), pd.DatetimeIndex


### PR DESCRIPTION
1) Removed the logic of checking the row index names in is_compatible_format()

2) Added logic of handling multiindex raw df. The idea is that it should be compatible with forcateri TimeSeries, as long as the index is pd.TimeStamp. 