### PR TITLE
metric align now renames the pred column names

### DIFF
--- a/forcateri/data/timeseries.py
+++ b/forcateri/data/timeseries.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, tzinfo
-from typing import List, Optional, Union, Tuple, Callable, Dict, Any
+from typing import List, Optional, Union, Tuple, Callable, Dict, Iterable, Any
 from pathlib import Path
 from typing_extensions import Self
 from pathlib import Path
@@ -1410,14 +1410,14 @@ class TimeSeries:
     def __deepcopy__(self, memo:Dict) -> TimeSeries:
         return self.copy(deep=True)
     
-    def rename_features(self, pattern: List[str] | Dict[str, str], in_place: bool = False) -> TimeSeries:
+    def rename_features(self, pattern: Iterable[str] | Dict[str, str], in_place: bool = False) -> TimeSeries:
         """
         Rename features in the TimeSeries.
         
         Parameters
         ----------
-        pattern : List[str] | Dict[str, str]
-            - If List[str]: replace all features in order with the provided names
+        pattern : Iterable[str] | Dict[str, str]
+            - If Iterable[str]: replace all features in order with the provided names
             - If Dict[str, str]: replace only the specified feature names (keys) with new names (values)
         in_place : bool, default=False
             If True, modifies the current TimeSeries object and returns `self`.
@@ -1434,7 +1434,7 @@ class TimeSeries:
         ValueError
             If pattern is a List and its length doesn't match the number of features
         TypeError
-            If pattern is neither a List nor a Dict
+            If pattern is neither an Iterable nor a Dict
         
         Examples
         --------
@@ -1460,8 +1460,16 @@ class TimeSeries:
         elif isinstance(pattern, dict):
             # Dict pattern: replace only specified features
             feature_mapping = pattern
+        elif hasattr(pattern, '__iter__'):
+            pattern_list = list(pattern)
+            if len(pattern_list) != len(current_features):
+                raise ValueError(
+                    f"Pattern length ({len(pattern)}) must match number of features ({len(current_features)}). "
+                    f"Current features: {current_features}"
+                )
+            feature_mapping = dict(zip(current_features,pattern_list))
         else:
-            raise TypeError("Pattern must be a List[str] or Dict[str, str]")
+            raise TypeError("Pattern must be a Iterable[str] or Dict[str, str]")
         
         # Rename the features in the columns
         new_columns = target_data.columns.map(

--- a/forcateri/data/timeseries.py
+++ b/forcateri/data/timeseries.py
@@ -1409,3 +1409,65 @@ class TimeSeries:
     
     def __deepcopy__(self, memo:Dict) -> TimeSeries:
         return self.copy(deep=True)
+    
+    def rename_features(self, pattern: List[str] | Dict[str, str]) -> TimeSeries:
+        """
+        Rename features in the TimeSeries.
+        
+        Parameters
+        ----------
+        pattern : List[str] | Dict[str, str]
+            - If List[str]: replace all features in order with the provided names
+            - If Dict[str, str]: replace only the specified feature names (keys) with new names (values)
+        
+        Returns
+        -------
+        TimeSeries
+            A new TimeSeries with renamed features
+        
+        Raises
+        ------
+        ValueError
+            If pattern is a List and its length doesn't match the number of features
+        TypeError
+            If pattern is neither a List nor a Dict
+        
+        Examples
+        --------
+        >>> ts = TimeSeries(data)  # with features: ['temp', 'humidity', 'pressure']
+        >>> 
+        >>> # Rename all features in order
+        >>> ts_renamed = ts.rename_features(['temperature', 'moisture', 'atm_pressure'])
+        >>> 
+        >>> # Rename only specific features
+        >>> ts_renamed = ts.rename_features({'temp': 'temperature', 'humidity': 'moisture'})
+        """
+        new_data = self.data.copy()
+        current_features = new_data.columns.get_level_values(0).unique().tolist()
+        
+        if isinstance(pattern, list):
+            # List pattern: replace all features in order
+            if len(pattern) != len(current_features):
+                raise ValueError(
+                    f"Pattern length ({len(pattern)}) must match number of features ({len(current_features)}). "
+                    f"Current features: {current_features}"
+                )
+            feature_mapping = dict(zip(current_features, pattern))
+        elif isinstance(pattern, dict):
+            # Dict pattern: replace only specified features
+            feature_mapping = pattern
+        else:
+            raise TypeError("Pattern must be a List[str] or Dict[str, str]")
+        
+        # Rename the features in the columns
+        new_columns = new_data.columns.map(
+            lambda x: (feature_mapping.get(x[0], x[0]), x[1]) if isinstance(x, tuple) else x
+        )
+        new_data.columns = new_columns
+        
+        return TimeSeries(
+            data=new_data,
+            representation=self._representation,
+            quantiles=self.quantiles,
+            freq=self.freq,
+        )

--- a/forcateri/data/timeseries.py
+++ b/forcateri/data/timeseries.py
@@ -1410,7 +1410,7 @@ class TimeSeries:
     def __deepcopy__(self, memo:Dict) -> TimeSeries:
         return self.copy(deep=True)
     
-    def rename_features(self, pattern: List[str] | Dict[str, str]) -> TimeSeries:
+    def rename_features(self, pattern: List[str] | Dict[str, str], in_place: bool = False) -> TimeSeries:
         """
         Rename features in the TimeSeries.
         
@@ -1419,11 +1419,15 @@ class TimeSeries:
         pattern : List[str] | Dict[str, str]
             - If List[str]: replace all features in order with the provided names
             - If Dict[str, str]: replace only the specified feature names (keys) with new names (values)
+        in_place : bool, default=False
+            If True, modifies the current TimeSeries object and returns `self`.
+            If False, returns a new TimeSeries instance with renamed features.
         
         Returns
         -------
         TimeSeries
-            A new TimeSeries with renamed features
+            The renamed TimeSeries. If `in_place=True`, returns the modified instance.
+            Otherwise, returns a new TimeSeries object with renamed features.
         
         Raises
         ------
@@ -1436,14 +1440,14 @@ class TimeSeries:
         --------
         >>> ts = TimeSeries(data)  # with features: ['temp', 'humidity', 'pressure']
         >>> 
-        >>> # Rename all features in order
+        >>> # Rename all features in order (returns new TimeSeries)
         >>> ts_renamed = ts.rename_features(['temperature', 'moisture', 'atm_pressure'])
         >>> 
-        >>> # Rename only specific features
-        >>> ts_renamed = ts.rename_features({'temp': 'temperature', 'humidity': 'moisture'})
+        >>> # Rename only specific features (in-place)
+        >>> ts.rename_features({'temp': 'temperature', 'humidity': 'moisture'}, in_place=True)
         """
-        new_data = self.data.copy()
-        current_features = new_data.columns.get_level_values(0).unique().tolist()
+        target_data = self.data if in_place else self.data.copy()
+        current_features = target_data.columns.get_level_values(0).unique().tolist()
         
         if isinstance(pattern, list):
             # List pattern: replace all features in order
@@ -1460,14 +1464,18 @@ class TimeSeries:
             raise TypeError("Pattern must be a List[str] or Dict[str, str]")
         
         # Rename the features in the columns
-        new_columns = new_data.columns.map(
+        new_columns = target_data.columns.map(
             lambda x: (feature_mapping.get(x[0], x[0]), x[1]) if isinstance(x, tuple) else x
         )
-        new_data.columns = new_columns
+        target_data.columns = new_columns
         
-        return TimeSeries(
-            data=new_data,
-            representation=self._representation,
-            quantiles=self.quantiles,
-            freq=self.freq,
-        )
+        if in_place:
+            self.data = target_data
+            return self
+        else:
+            return TimeSeries(
+                data=target_data,
+                representation=self._representation,
+                quantiles=self.quantiles,
+                freq=self.freq,
+            )

--- a/forcateri/model/dartsmodeladapter.py
+++ b/forcateri/model/dartsmodeladapter.py
@@ -586,12 +586,14 @@ class DartsModelAdapter(ModelAdapter, ABC):
                     logger.debug(
                         "Converting single DartsTimeSeries with quantiles to TimeSeries"
                     )
+                    clean_cols_list = list({col.rsplit('_', 1)[0] for col in darts_df.columns})
                     ts_obj = TimeSeries(
                         data=darts_df,
                         representation=TimeSeries.QUANTILE_REP,
                         quantiles=quantiles,
                         freq=freq,
                     )
+                    ts_obj.rename_features(pattern=clean_cols_list, in_place=True)
                 elif num_samples is not None and num_samples > 1:
                     logger.debug(
                         "Converting single DartsTimeSeries with samples to TimeSeries"
@@ -627,6 +629,7 @@ class DartsModelAdapter(ModelAdapter, ABC):
                 return TimeSeries(
                     data=df, representation=TimeSeries.QUANTILE_REP, quantiles=quantiles
                 )
+
             else:
                 return TimeSeries(data=df, representation=TimeSeries.DETERM_REP)
         else:

--- a/forcateri/reporting/metric.py
+++ b/forcateri/reporting/metric.py
@@ -65,6 +65,17 @@ class Metric:
             )
         else:
             logger.debug("No time steps were dropped during alignment.")
+        gt_features = ts_gt_shifted.data.columns.get_level_values('feature').unique()
+        pred_features = prediction.data.columns.get_level_values('feature').unique()
+        if len(gt_features) == len(pred_features) and not gt_features.equals(pred_features):
+            # Create a mapping from prediction features to ground truth features
+            rename_map = dict(zip(pred_features, gt_features))
+            logger.debug(f"Renaming prediction features: {rename_map}")
+            # Rename the feature level in the prediction columns
+            new_column_index = prediction.data.columns.to_frame(index=False).copy()
+            new_column_index['feature'] = new_column_index['feature'].map(rename_map)
+            prediction.data.columns = pd.MultiIndex.from_frame(new_column_index)
+            logger.debug(f"Prediction columns after rename: {prediction.data.columns}")
         return ts_gt_shifted, prediction
 
     def __call__(self, ground_truth: TimeSeries, prediction: TimeSeries) -> Any:

--- a/forcateri/reporting/metric.py
+++ b/forcateri/reporting/metric.py
@@ -78,14 +78,7 @@ class Metric:
         gt_features = ts_gt_shifted.data.columns.get_level_values('feature').unique()
         pred_features = prediction.data.columns.get_level_values('feature').unique()
         if len(gt_features) == len(pred_features) and not gt_features.equals(pred_features):
-            # Create a mapping from prediction features to ground truth features
-            rename_map = dict(zip(pred_features, gt_features))
-            logger.debug(f"Renaming prediction features: {rename_map}")
-            # Rename the feature level in the prediction columns
-            new_column_index = prediction.data.columns.to_frame(index=False).copy()
-            new_column_index['feature'] = new_column_index['feature'].map(rename_map)
-            prediction.data.columns = pd.MultiIndex.from_frame(new_column_index)
-            logger.debug(f"Prediction columns after rename: {prediction.data.columns}")
+            logger.error(f"cannot align features with different names")
         return ts_gt_shifted, prediction
 
     def __call__(self, ground_truth: TimeSeries, prediction: TimeSeries) -> Any:


### PR DESCRIPTION
Stumbled upon an old issue of mismatch between the target and predicted feature namings.
Automatically align prediction feature names with ground truth feature names when the number of features matches but the names differ.
Changes made:

- Detect mismatched feature names between predictions and ground truth.
- Rename prediction feature columns using a position-based mapping.
- Add debug logging for the generated mapping and updated columns.